### PR TITLE
Fix project name typo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'BItShares Developers Portal'
+project = u'BitShares Developers Portal'
 copyright = u'2019 BitShares Blockchain Foundation'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
The project name is also used as title of each html page:

```
  <title>Use Cases &mdash; BItShares Developers Portal  documentation</title>
```

this PR fix the typo in project name and should fix also that title.