### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-dev.bitshares.works


### PR DESCRIPTION
We decided to no longer use the bitshares.works domain.