### PR TITLE
Try to fix docs build due to readthedocs changes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,10 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-lts-latest
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
We received the error:

```
Config validation error in build.os. Value build not found.
```

This patch fixes the error by specifying the `build.os` value according to https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os